### PR TITLE
Changed commit compare repo to nixpkgs

### DIFF
--- a/src/telegram.js
+++ b/src/telegram.js
@@ -100,8 +100,8 @@ export function generateDiff(chan, oldData, newData, comp) {
     if (newData.gitRev) {
         linkSegParts.push(
             (oldData === null || oldData.gitRev === null)
-            ? `[GitHub (${newData.gitRev.slice(0, 7)})](https://github.com/NixOS/nixpkgs-channels/commits/${newData.gitRev})`
-            : `[GitHub (${newData.gitRev.slice(0, 7)})](https://github.com/NixOS/nixpkgs-channels/compare/${oldData.gitRev}...${newData.gitRev})`
+            ? `[GitHub (${newData.gitRev.slice(0, 7)})](https://github.com/NixOS/nixpkgs/commits/${newData.gitRev})`
+            : `[GitHub (${newData.gitRev.slice(0, 7)})](https://github.com/NixOS/nixpkgs/compare/${oldData.gitRev}...${newData.gitRev})`
         );
     }
 


### PR DESCRIPTION
When I go to the github link it generates github shows that the commits aren't found, so I tried changing the repo from nixpkgs-channels to nixpkgs and it worked.

![Screenshot_2020-11-15-18-27-23-499_org mozilla firefox](https://user-images.githubusercontent.com/15693688/99197294-663c9980-2770-11eb-8086-6215692c570f.jpg)

BTW thank you for this awesome bot, now I am pinning the nixpkgs revision and this bot helps me know when there is a new build in my channel without sacrificing the public cache. 